### PR TITLE
QFE: Detect and document duplicate feature names

### DIFF
--- a/src/scanner.h
+++ b/src/scanner.h
@@ -104,6 +104,8 @@ namespace mach2
         void ExecuteCallback(std::wstring const& path);
         std::wstring GetFeatureNameFromSymbolName(std::wstring const &symbolName);
         void GetFeaturesFromSymbolAtPath(std::wstring const &path, mach2::Scanner::Features &features);
+        bool HasDuplicateFeatureWithId(std::int64_t featureId, std::wstring& featureName, mach2::Scanner::Features& features);
+        std::wstring GetUniqueNameForDuplicateFeature(mach2::Scanner::Feature& feature, mach2::Scanner::Features& features);
         void InternalGetMissingFeatureIdsFromImagesAtPath(mach2::Scanner::Features& features, std::wstring const& image_path);
         void GetMissingFeatureIdsFromImageAtPath(std::wstring const& path, mach2::Scanner::Features& features);
         void InternalGetFeaturesFromSymbolsAtPath(std::wstring const &symbols_path, mach2::Scanner::Features &features);


### PR DESCRIPTION
`Stubification` is duplicated in 21277. Quick fix to detect and warn the user of duplicates with `|mach2.warning.duplicate{0-9}` label. Associated symbols in duplicate scenarios will be somewhat unreliable (duplicated).
